### PR TITLE
Update to pass in rng, change Zcash sapling address rng to StdRng

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,16 +36,18 @@ wagu-model = { path = "./model" }
 monero = { path = "./monero" }
 zcash = { path = "./zcash" }
 
-arrayvec = "0.4.7"
-base58 = "0.1"
-clap = "~2.33.0"
-digest = "0.7.5"
-either = "1.5.0"
-lazy_static = "1.1.0"
-safemem = "0.3.0"
+arrayvec = { version = "0.4.7" }
+base58 = { version = "0.1" }
+clap = { version = "~2.33.0" }
+digest = { version = "0.7.5" }
+either = { version = "1.5.0" }
+lazy_static = { version = "1.1.0" }
+rand = { version = "0.7" }
+rand_core = { version = "0.5.0" }
+safemem = { version = "0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tiny-keccak = "1.4"
+serde_json = { version = "1.0" }
+tiny-keccak = { version = "1.4" }
 
 [profile.release]
 opt-level = 3

--- a/bitcoin/src/private_key.rs
+++ b/bitcoin/src/private_key.rs
@@ -4,7 +4,6 @@ use crate::public_key::BitcoinPublicKey;
 use wagu_model::{crypto::checksum, Address, AddressError, PrivateKey, PrivateKeyError, PublicKey};
 
 use base58::{FromBase58, ToBase58};
-use rand::rngs::OsRng;
 use rand::Rng;
 use secp256k1;
 use std::marker::PhantomData;
@@ -28,13 +27,10 @@ impl<N: BitcoinNetwork> PrivateKey for BitcoinPrivateKey<N> {
     type PublicKey = BitcoinPublicKey<N>;
 
     /// Returns a randomly-generated compressed Bitcoin private key.
-    fn new() -> Result<Self, PrivateKeyError> {
-        let mut random = [0u8; 32];
-        OsRng.try_fill(&mut random)?;
-        let secret_key = secp256k1::SecretKey::from_slice(&random)?;
-
+    fn new<R: Rng>(rng: &mut R) -> Result<Self, PrivateKeyError> {
+        let random: [u8; 32] = rng.gen();
         Ok(Self {
-            secret_key,
+            secret_key: secp256k1::SecretKey::from_slice(&random)?,
             compressed: true,
             _network: PhantomData,
         })

--- a/ethereum/src/private_key.rs
+++ b/ethereum/src/private_key.rs
@@ -2,7 +2,6 @@ use crate::address::EthereumAddress;
 use crate::public_key::EthereumPublicKey;
 use wagu_model::{Address, AddressError, PrivateKey, PrivateKeyError, PublicKey};
 
-use rand::rngs::OsRng;
 use rand::Rng;
 use secp256k1;
 use std::marker::PhantomData;
@@ -19,9 +18,8 @@ impl PrivateKey for EthereumPrivateKey {
     type PublicKey = EthereumPublicKey;
 
     /// Returns a randomly-generated Ethereum private key.
-    fn new() -> Result<Self, PrivateKeyError> {
-        let mut random = [0u8; 32];
-        OsRng.try_fill(&mut random)?;
+    fn new<R: Rng>(rng: &mut R) -> Result<Self, PrivateKeyError> {
+        let random: [u8; 32] = rng.gen();
         Ok(Self(secp256k1::SecretKey::from_slice(&random)?))
     }
 

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -24,6 +24,7 @@ byteorder = { version = "1" }
 crypto-mac = { version = "0.7.0" }
 failure = { version = "0.1.5" }
 hex = { version = "0.3.2" }
+rand = { version = "0.7" }
 rand_core = { version = "0.5.0" }
 ripemd160 = { version = "0.8" }
 secp256k1 = { version = "0.15.0" }

--- a/model/src/private_key.rs
+++ b/model/src/private_key.rs
@@ -1,6 +1,7 @@
 use crate::address::{Address, AddressError};
 use crate::public_key::PublicKey;
 
+use rand::Rng;
 use std::{
     fmt::{Debug, Display},
     str::FromStr,
@@ -13,7 +14,7 @@ pub trait PrivateKey: Clone + Debug + Display + FromStr + Send + Sync + 'static 
     type PublicKey: PublicKey;
 
     /// Returns a randomly-generated private key.
-    fn new() -> Result<Self, PrivateKeyError>;
+    fn new<R: Rng>(rng: &mut R) -> Result<Self, PrivateKeyError>;
 
     /// Returns the public key of the corresponding private key.
     fn to_public_key(&self) -> Self::PublicKey;

--- a/monero/src/mnemonic.rs
+++ b/monero/src/mnemonic.rs
@@ -6,7 +6,6 @@ use crate::wordlist::MoneroWordlist;
 use wagu_model::{Mnemonic, MnemonicError, PrivateKey};
 
 use crc::{crc32, Hasher32};
-use rand::rngs::OsRng;
 use rand::Rng;
 use std::fmt;
 use std::marker::PhantomData;
@@ -54,9 +53,8 @@ impl<N: MoneroNetwork, W: MoneroWordlist> Mnemonic for MoneroMnemonic<N, W> {
 
 impl<N: MoneroNetwork, W: MoneroWordlist> MoneroMnemonic<N, W> {
     /// Returns a new mnemonic phrase given the word count.
-    pub fn new() -> Result<Self, MnemonicError> {
-        let mut seed = [0u8; 32];
-        OsRng.try_fill(&mut seed)?;
+    pub fn new<R: Rng>(rng: &mut R) -> Result<Self, MnemonicError> {
+        let seed: [u8; 32] = rng.gen();
         Ok(Self::from_seed(&seed)?)
     }
 
@@ -196,7 +194,8 @@ mod tests {
     use hex;
 
     fn test_new<N: MoneroNetwork, W: MoneroWordlist>() {
-        let result = MoneroMnemonic::<N, W>::new().unwrap();
+        let rng = &mut rand::thread_rng();
+        let result = MoneroMnemonic::<N, W>::new(rng).unwrap();
         test_from_seed::<N, W>(&result.phrase, &result.seed);
     }
 

--- a/monero/src/private_key.rs
+++ b/monero/src/private_key.rs
@@ -5,7 +5,7 @@ use wagu_model::{Address, AddressError, PrivateKey, PrivateKeyError, PublicKey};
 
 use curve25519_dalek::scalar::Scalar;
 use hex;
-use rand::{rngs::OsRng, Rng};
+use rand::Rng;
 use std::{fmt, fmt::Display, marker::PhantomData, str::FromStr};
 use tiny_keccak::keccak256;
 
@@ -28,9 +28,8 @@ impl<N: MoneroNetwork> PrivateKey for MoneroPrivateKey<N> {
     type PublicKey = MoneroPublicKey<N>;
 
     /// Returns a randomly-generated Monero private key.
-    fn new() -> Result<Self, PrivateKeyError> {
-        let mut random = [0u8; 32];
-        OsRng.try_fill(&mut random)?;
+    fn new<R: Rng>(rng: &mut R) -> Result<Self, PrivateKeyError> {
+        let random: [u8; 32] = rng.gen();
         Self::from_seed(hex::encode(random).as_str(), &Format::Standard)
     }
 

--- a/wagu/cli.rs
+++ b/wagu/cli.rs
@@ -12,6 +12,8 @@ use zcash::address::Format as ZcashFormat;
 use zcash::{Mainnet as ZcashMainnet, Testnet as ZcashTestnet, ZcashAddress, ZcashPrivateKey};
 
 use clap::{App, Arg};
+use rand::rngs::StdRng;
+use rand_core::SeedableRng;
 use serde::Serialize;
 use std::marker::PhantomData;
 
@@ -109,7 +111,8 @@ fn print_bitcoin_wallet(count: usize, testnet: bool, format: &BitcoinFormat, jso
     };
 
     let wallet = if testnet {
-        let private_key = BitcoinPrivateKey::<BitcoinTestnet>::new().unwrap();
+        let rng = &mut StdRng::from_entropy();
+        let private_key = BitcoinPrivateKey::<BitcoinTestnet>::new(rng).unwrap();
         let address = BitcoinAddress::from_private_key(&private_key, &format).unwrap();
 
         Wallet {
@@ -119,7 +122,8 @@ fn print_bitcoin_wallet(count: usize, testnet: bool, format: &BitcoinFormat, jso
             compressed: private_key.is_compressed(),
         }
     } else {
-        let private_key = BitcoinPrivateKey::<BitcoinMainnet>::new().unwrap();
+        let rng = &mut StdRng::from_entropy();
+        let private_key = BitcoinPrivateKey::<BitcoinMainnet>::new(rng).unwrap();
         let address = BitcoinAddress::from_private_key(&private_key, &format).unwrap();
 
         Wallet {
@@ -154,7 +158,8 @@ fn print_ethereum_wallet(count: usize, json: bool) {
         address: String,
     };
 
-    let private_key = EthereumPrivateKey::new().unwrap();
+    let rng = &mut StdRng::from_entropy();
+    let private_key = EthereumPrivateKey::new(rng).unwrap();
     let address = EthereumAddress::from_private_key(&private_key, &PhantomData).unwrap();
 
     let wallet = Wallet {
@@ -187,7 +192,8 @@ fn print_monero_wallet(count: usize, testnet: bool, json: bool) {
 
     // TODO (howardwu): Add support for all Monero formats.
     let wallet = if testnet {
-        let private_key = MoneroPrivateKey::<MoneroTestnet>::new().unwrap();
+        let rng = &mut StdRng::from_entropy();
+        let private_key = MoneroPrivateKey::<MoneroTestnet>::new(rng).unwrap();
         let address = MoneroAddress::from_private_key(&private_key, &MoneroFormat::Standard).unwrap();
 
         Wallet {
@@ -196,7 +202,8 @@ fn print_monero_wallet(count: usize, testnet: bool, json: bool) {
             network: "testnet".into(),
         }
     } else {
-        let private_key = MoneroPrivateKey::<MoneroMainnet>::new().unwrap();
+        let rng = &mut StdRng::from_entropy();
+        let private_key = MoneroPrivateKey::<MoneroMainnet>::new(rng).unwrap();
         let address = MoneroAddress::from_private_key(&private_key, &MoneroFormat::Standard).unwrap();
 
         Wallet {
@@ -230,7 +237,8 @@ fn print_zcash_wallet(count: usize, testnet: bool, format: &ZcashFormat, json: b
     };
 
     let wallet = if testnet {
-        let private_key = ZcashPrivateKey::<ZcashTestnet>::new().unwrap();
+        let rng = &mut StdRng::from_entropy();
+        let private_key = ZcashPrivateKey::<ZcashTestnet>::new(rng).unwrap();
         let address = ZcashAddress::from_private_key(&private_key, &format).unwrap();
 
         Wallet {
@@ -239,7 +247,8 @@ fn print_zcash_wallet(count: usize, testnet: bool, format: &ZcashFormat, json: b
             network: "testnet".into(),
         }
     } else {
-        let private_key = ZcashPrivateKey::<ZcashMainnet>::new().unwrap();
+        let rng = &mut StdRng::from_entropy();
+        let private_key = ZcashPrivateKey::<ZcashMainnet>::new(rng).unwrap();
         let address = ZcashAddress::from_private_key(&private_key, &format).unwrap();
 
         Wallet {

--- a/zcash/Cargo.toml
+++ b/zcash/Cargo.toml
@@ -27,6 +27,7 @@ bech32 = { version = "0.6" }
 base58 = { version = "0.1" }
 hex = { version = "0.3.2" }
 rand = { version = "0.7" }
+rand_core = { version = "0.5.0" }
 ripemd160 = { version = "0.7" }
 secp256k1 = { version = "0.15.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/zcash/src/address.rs
+++ b/zcash/src/address.rs
@@ -8,8 +8,8 @@ use wagu_model::{
 
 use base58::{FromBase58, ToBase58};
 use bech32::{Bech32, FromBase32, ToBase32};
+use rand::{rngs::StdRng, Rng};
 use rand_core::SeedableRng;
-use rand::{Rng, rngs::StdRng};
 use sapling_crypto::primitives::Diversifier;
 use serde::Serialize;
 use std::fmt;

--- a/zcash/src/address.rs
+++ b/zcash/src/address.rs
@@ -8,8 +8,8 @@ use wagu_model::{
 
 use base58::{FromBase58, ToBase58};
 use bech32::{Bech32, FromBase32, ToBase32};
-use rand::rngs::OsRng;
-use rand::Rng;
+use rand_core::SeedableRng;
+use rand::{Rng, rngs::StdRng};
 use sapling_crypto::primitives::Diversifier;
 use serde::Serialize;
 use std::fmt;
@@ -123,9 +123,13 @@ impl<N: ZcashNetwork> ZcashAddress<N> {
 
     /// Returns a shielded address from a given Zcash public key.
     pub fn sapling(public_key: &SaplingViewingKey, format: &Format) -> Result<Self, AddressError> {
-        let data = match format {
-            Format::Sapling(data) => data.unwrap_or([0u8; 11]),
-            _ => [0u8; 11],
+        // Randomness seeded by `getrandom`, which interfaces with the operating system
+        // https://docs.rs/getrandom/
+        let rng = &mut StdRng::from_entropy();
+
+        let mut data: [u8; 11] = match format {
+            Format::Sapling(data) => data.unwrap_or(rng.gen()),
+            _ => rng.gen(),
         };
 
         let address;
@@ -136,8 +140,7 @@ impl<N: ZcashNetwork> ZcashAddress<N> {
                 diversifier = data;
                 break;
             }
-            let mut data = [0u8; 11];
-            OsRng.try_fill(&mut data)?;
+            data = rng.gen();
         }
 
         let mut checked_data = vec![0; 43];

--- a/zcash/src/private_key.rs
+++ b/zcash/src/private_key.rs
@@ -5,7 +5,6 @@ use wagu_model::{crypto::checksum, Address, AddressError, PrivateKey, PrivateKey
 
 use base58::{FromBase58, ToBase58};
 use pairing::bls12_381::Bls12;
-use rand::rngs::OsRng;
 use rand::Rng;
 use secp256k1;
 use std::cmp::{Eq, PartialEq};
@@ -145,9 +144,8 @@ impl<N: ZcashNetwork> PrivateKey for ZcashPrivateKey<N> {
     type PublicKey = ZcashPublicKey<N>;
 
     /// Returns a randomly-generated compressed Zcash private key.
-    fn new() -> Result<Self, PrivateKeyError> {
-        let mut random = [0u8; 32];
-        OsRng.try_fill(&mut random)?;
+    fn new<R: Rng>(rng: &mut R) -> Result<Self, PrivateKeyError> {
+        let random: [u8; 32] = rng.gen();
         Ok(Self(
             SpendingKey::<N>::P2PKH(P2PKHSpendingKey::<N>::new(
                 secp256k1::SecretKey::from_slice(&random)?,


### PR DESCRIPTION
Removes use of OsRng, in favor of caller providing an Rng of their choice.

- Zcash addresses now use StdRng for generating diversifiers.

- This change in randomness should help to enable wasm support.